### PR TITLE
Chore: Update Circleci Node orb to 4.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@3.0.0
+  node: circleci/node@4.3.0
 
 executors:
   linux:


### PR DESCRIPTION
Update Circleci Node orb to `4.3.0`