### PR TITLE
Chore: Update circleci/node orb and install missing CURL tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,17 +12,18 @@ executors:
 commands:
   install_dependencies:
     steps:
+      - upgrade_node
       - checkout
+      - node/install-packages:
+          pkg-manager: yarn
+  upgrade_node:
+    steps:
       - run: node --version
       - run: apt-get update && apt-get install -y curl
       - run: curl --version
-#      - run: nvm --version
       - node/install:
-#          install-yarn: true
           node-version: '16.15'
       - run: node --version
-      - node/install-packages:
-          pkg-manager: yarn
 
 jobs:
   setup:
@@ -37,6 +38,7 @@ jobs:
   yarn_lint:
     executor: linux
     steps:
+      - upgrade_node
       - attach_workspace:
           at: ./
       - run: yarn lint
@@ -44,6 +46,7 @@ jobs:
   yarn_test:
     executor: linux
     steps:
+      - upgrade_node
       - attach_workspace:
           at: ./
       - run: yarn test
@@ -51,6 +54,7 @@ jobs:
   yarn_test_parallel:
     executor: linux
     steps:
+      - upgrade_node
       - attach_workspace:
           at: ./
       - run: yarn test-run-multiple

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@4.3.0
+  node: circleci/node@5.0.2
 
 executors:
   linux:
@@ -13,6 +13,14 @@ commands:
   install_dependencies:
     steps:
       - checkout
+      - run: node --version
+      - run: apt-get update && apt-get install -y curl
+      - run: curl --version
+#      - run: nvm --version
+      - node/install:
+#          install-yarn: true
+          node-version: '16.15'
+      - run: node --version
       - node/install-packages:
           pkg-manager: yarn
 


### PR DESCRIPTION
This change includes:
- circleci/node orb update to `5.0.2`
- installation of missing CURL tool for each parallel pipeline job