### PR TITLE
Feature: Run browsers in visible/headed mode from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Example usage of CodeceptJS test framework
 - parallelised example = `yarn test-run-multiple`
     - shards by 'Feature' (i.e. by test file)
 - CircleCI test pipelines (`yarn_lint`, `yarn_test`, `yarn_test_parallel`)
+- make browser testing visible from the commandline by prefixing test commands with `SHOW_BROWSER=true` 
 
 
 ## TODO:

--- a/config/codecept.conf.js
+++ b/config/codecept.conf.js
@@ -6,7 +6,7 @@ exports.config = {
   helpers: {
     Puppeteer: {
       url: 'http://www.whiteboxitsolutions.com',
-      show: false,  // headless by default to run on CircleCI unix box
+      show: process.env.SHOW_BROWSER || false,  // headless by default to run on CircleCI unix box
       waitForTimeout: 10000,
       waitForAction: 500,
       chrome: {

--- a/config/run-multiple.conf.js
+++ b/config/run-multiple.conf.js
@@ -12,7 +12,7 @@ exports.config = {
   helpers: {
     Puppeteer: {
       url: 'http://www.whiteboxitsolutions.com',
-      show: false,  // headless by default to run on CircleCI unix box
+      show: process.env.SHOW_BROWSER || false,  // headless by default to run on CircleCI unix box
       waitForTimeout: 10000,
       waitForAction: 500,
       chrome: {


### PR DESCRIPTION
Run browsers in visible/headed mode by prefixing test commands with `SHOW_BROWSER=true`:
```
SHOW_BROWSER=true yarn test
SHOW_BROWSER=true yarn test-run-multiple
```